### PR TITLE
Allow for single-stage KDFs

### DIFF
--- a/draft-barnes-hpke-hpke.md
+++ b/draft-barnes-hpke-hpke.md
@@ -226,6 +226,8 @@ informative:
   keyagreement: DOI.10.6028/NIST.SP.800-56Ar3
 
   NISTCurves: DOI.10.6028/NIST.FIPS.186-4
+  
+  FIPS202: DOI.10.6028/NIST.FIPS.202
 
   GCM: DOI.10.6028/NIST.SP.800-38D
 
@@ -307,6 +309,10 @@ operations, roles, and behaviors of HPKE:
   described in {{!RFC8017}}, assuming big-endian byte order.
 - `concat(x0, ..., xN)`: Concatenation of byte strings.
   `concat(0x01, 0x0203, 0x040506) = 0x010203040506`.
+- `lengthPrefixed(x)`: The two-byte length of the byte string `x`, concatenated
+  with `x` itself.  (`lengthPrefixed(x) = concat(I2OSP(len(x), 2), x)`)  It is
+  an error to call this function with an `x` value that is more than 65535 bytes
+  long.
 - `random(n)`: A pseudorandom byte string of length `n` bytes
 - `xor(a,b)`: XOR of byte strings; `xor(0xF0F0, 0x1234) = 0xE2C4`.
   It is an error to call this function with two arguments of unequal
@@ -346,13 +352,20 @@ HPKE variants rely on the following primitives:
   - `Npk`: The length in bytes of an encoded public key for this KEM.
   - `Nsk`: The length in bytes of an encoded private key for this KEM.
 
-* A key derivation function (KDF):
-  - `Extract(salt, ikm)`: Extract a pseudorandom key of fixed length `Nh` bytes
-    from input keying material `ikm` and an optional byte string
-    `salt`.
-  - `Expand(prk, info, L)`: Expand a pseudorandom key `prk` using
-    optional string `info` into `L` bytes of output keying material.
-  - `Nh`: The output size of the `Extract()` function in bytes.
+* A key derivation function (KDF) of one of the two following forms:
+
+  * A single-stage KDF:
+    - `Derive(ikm, L)`: Derive an `L`-byte value from the input keying material
+      `ikm`.
+    - `Nh` The security strength of the KDF, in bytes.
+  
+  * A two-stage KDF:
+    - `Extract(salt, ikm)`: Extract a pseudorandom key of fixed length `Nh` bytes
+      from input keying material `ikm` and an optional byte string
+      `salt`.
+    - `Expand(prk, info, L)`: Expand a pseudorandom key `prk` using
+      optional string `info` into `L` bytes of output keying material.
+    - `Nh`: The output size of the `Extract()` function in bytes.
 
 * An AEAD encryption algorithm {{!RFC5116}}:
   - `Seal(key, nonce, aad, pt)`: Encrypt and authenticate plaintext
@@ -391,7 +404,7 @@ computation of the public key using the private key, or just syntax
 expressing the retrieval of the public key, assuming it is stored along
 with the private key object.
 
-The following two functions are defined to facilitate domain separation of
+The following functions are defined to facilitate domain separation of
 KDF calls as well as context binding:
 
 ~~~
@@ -403,6 +416,10 @@ def LabeledExpand(prk, label, info, L):
   labeled_info = concat(I2OSP(L, 2), "HPKE-v1", suite_id,
                         label, info)
   return Expand(prk, labeled_info, L)
+
+def LabeledDerive(ikm, label, L):
+  labeled_ikm = concat("HPKE_v1", suite_id, label, ikm)
+  return Derive(labeled_ikm, L)
 ~~~
 
 The value of `suite_id` depends on where the KDF is used; it is assumed
@@ -436,6 +453,15 @@ for the Diffie-Hellman group in use. {{derive-key-pair}} contains the
 `DeriveKeyPair()` function specification for DHKEMs defined in this document.
 
 ~~~
+# For use with single-stage KDFs
+def ExtractAndExpand(dh, kem_context):
+  derive_input = concat(
+    lengthPrefixed(dh), 
+    lengthPrefixed(shared_secret)
+  )
+  return LabeledDerive(derive_input, "shared_secret", Nsecret)
+
+# For use with two-stage KDFs
 def ExtractAndExpand(dh, kem_context):
   eae_prk = LabeledExtract("", "eae_prk", dh)
   shared_secret = LabeledExpand(eae_prk, "shared_secret",
@@ -487,9 +513,8 @@ def AuthDecap(enc, skR, pkS):
   return shared_secret
 ~~~
 
-The implicit `suite_id` value used within `LabeledExtract` and
-`LabeledExpand` is defined as follows, where `kem_id` is defined
-in {{kem-ids}}:
+The implicit `suite_id` value used within `LabeledExtract`, `LabeledExpand`, and
+`LabeledDerive` is defined as follows, where `kem_id` is defined in {{kem-ids}}:
 
 ~~~
 suite_id = concat("KEM", I2OSP(kem_id, 2))
@@ -498,7 +523,7 @@ suite_id = concat("KEM", I2OSP(kem_id, 2))
 The KDF used in DHKEM can be equal to or different from the KDF used
 in the remainder of HPKE, depending on the chosen variant.
 Implementations MUST make sure to use the constants (`Nh`) and function
-calls (`LabeledExtract` and `LabeledExpand`) of the appropriate KDF when
+calls (`LabeledExtract`, `LabeledExpand`, and `LabeledDerive`) of the appropriate KDF when
 implementing DHKEM. See {{kdf-choice}} for a comment on the choice of
 a KDF for the remainder of HPKE, and {{domain-separation}} for the
 rationale of the labels.
@@ -623,7 +648,7 @@ The HPKE algorithm identifiers, i.e., the KEM `kem_id`, KDF `kdf_id`, and
 AEAD `aead_id` 2-byte code points, as defined in {{kemid-values}}, {{kdfid-values}},
 and {{aeadid-values}}, respectively, are assumed implicit from the implementation
 and not passed as parameters. The implicit `suite_id` value used within
-`LabeledExtract` and `LabeledExpand` is defined based on them as follows:
+`LabeledExtract`, `LabeledExpand`, and `LabeledDerive` is defined based on them as follows:
 
 ~~~
 suite_id = concat(
@@ -649,9 +674,26 @@ def VerifyPSKInputs(mode, psk, psk_id):
   if (not got_psk) and (mode in [mode_psk, mode_auth_psk]):
     raise Exception("Missing required PSK input")
 
-def KeySchedule<ROLE>(mode, shared_secret, info, psk, psk_id):
-  VerifyPSKInputs(mode, psk, psk_id)
+# For use with a single-stage KDF
+def CombineSecrets(mode, shared_secret, info, psk, psk_id):
+  derive_input = concat(
+    lengthPrefixed(psk),
+    lengthPrefixed(shared_secret),
+    mode,
+    lengthPrefixed(psk_id),
+    lengthPrefixed(info),
+  )
 
+  secret = LabeledDerive(derive_input, "secret", Nk + Nn + Nh)
+
+  key = secret[:Nk]
+  base_nonce = secret[Nk:(Nk + Nn)]
+  exporter_secret = secret[(Nk + Nn):]
+
+  return (key, base_nonce, exporter_secret)
+
+# For use with a two-stage KDF
+def CombineSecrets(mode, shared_secret, info, psk, psk_id):
   psk_id_hash = LabeledExtract("", "psk_id_hash", psk_id)
   info_hash = LabeledExtract("", "info_hash", info)
   key_schedule_context = concat(mode, psk_id_hash, info_hash)
@@ -664,6 +706,14 @@ def KeySchedule<ROLE>(mode, shared_secret, info, psk, psk_id):
   exporter_secret = LabeledExpand(secret, "exp",
                                   key_schedule_context, Nh)
 
+  return (key, base_nonce, exporter_secret)
+
+def KeySchedule<ROLE>(mode, shared_secret, info, psk, psk_id):
+  VerifyPSKInputs(mode, psk, psk_id)
+
+  key, base_nonce, exporter_secret =
+    CombineSecrets(mode, shared_secret, info, psk, psk_id)
+  
   return Context<ROLE>(key, base_nonce, 0, exporter_secret)
 ~~~~~
 
@@ -897,6 +947,12 @@ used together with them. See {{kdf-input-length}} for precise limits on this
 length.
 
 ~~~~~
+# For use with a single-stage KDF
+def Context.Export(exporter_context, L):
+  derive_input = concat(self.exporter_secret, exporter_context)
+  return LabeledDerive(derive_input, "sec", L)
+
+# For use with a two-stage KDF
 def Context.Export(exporter_context, L):
   return LabeledExpand(self.exporter_secret, "sec",
                        exporter_context, L)
@@ -1043,15 +1099,25 @@ For P-256, P-384, and P-521, the `DeriveKeyPair()` function of the KEM performs
 rejection sampling over field elements:
 
 ~~~
-def DeriveKeyPair(ikm):
+# For use with a single-stage KDF
+def DeriveCandidate(ikm, counter):
+  derive_input = concat(I2OSP(counter, 1), ikm)
+  return LabeledDerive(derive_input, "candidate", Nsk)
+
+# For use with a two-stage KDF
+def DeriveCandidate(ikm, counter):
+  # Note: dkp_prk may be derived once and cached
   dkp_prk = LabeledExtract("", "dkp_prk", ikm)
+  return LabeledExpand(dkp_prk, "candidate",
+                          I2OSP(counter, 1), Nsk)
+
+def DeriveKeyPair(ikm):
   sk = 0
   counter = 0
   while sk == 0 or sk >= order:
     if counter > 255:
       raise DeriveKeyPairError
-    bytes = LabeledExpand(dkp_prk, "candidate",
-                          I2OSP(counter, 1), Nsk)
+    bytes = DeriveCandidate(ikm, counter)
     bytes[0] = bytes[0] & bitmask
     sk = OS2IP(bytes)
     counter = counter + 1
@@ -1082,6 +1148,12 @@ See {{api-errors}} for information about dealing with such failures.
 For X25519 and X448, the `DeriveKeyPair()` function applies a KDF to the input:
 
 ~~~
+# For use with a single-stage KDF
+def DeriveKeyPair(ikm):
+  sk = LabeledDerive(ikm, "sk", Nsk)
+  return (sk, pk(sk))
+
+# For use with a two-stage KDF
 def DeriveKeyPair(ikm):
   dkp_prk = LabeledExtract("", "dkp_prk", ikm)
   sk = LabeledExpand(dkp_prk, "sk", "", Nsk)
@@ -1131,6 +1203,8 @@ algorithm whose output length is `Npk`.
 {: #kdfid-values title="KDF IDs"}
 
 ### Input Length Restrictions {#kdf-input-length}
+
+[[ TODO(RLB): Determine what this section should say about single-stage KDFs. ]]
 
 This document defines `LabeledExtract()` and `LabeledExpand()` based on the
 KDFs listed above. These functions add prefixes to their respective
@@ -1572,16 +1646,20 @@ calls to `Extract()` and `Expand()` inside DHKEM and the remainder of
 HPKE use separate input domains. This justifies modeling them as
 independent functions even if instantiated by the same KDF.
 This domain separation between DHKEM and the remainder of HPKE is achieved by
-using prefix-free sets of `suite_id` values in `LabeledExtract()` and
-`LabeledExpand()` (`KEM...` in DHKEM and `HPKE...` in the remainder of HPKE).
+using prefix-free sets of `suite_id` values in `LabeledExtract()`,
+`LabeledExpand()`, and LabeledDerive (`KEM...` in DHKEM and `HPKE...` in the remainder of HPKE).
 Recall that a set is prefix-free if no element is a prefix of another within the
 set.
 
-Future KEM instantiations MUST ensure, should `Extract()` and
-`Expand()` be used internally, that they can be modeled as functions
-independent from the invocations of `Extract()` and `Expand()` in the
-remainder of HPKE. One way to ensure this is by using `LabeledExtract()`
-and `LabeledExpand()` with a `suite_id` as defined in {{base-crypto}},
+Separation between uses of the single-stage and two-stage KDFs is ensured by the
+inclusion of the `suite_id` in `LabeledExtract`, `LabeledExpand`, and
+`LabeledDerive`.
+
+Future KEM instantiations MUST ensure, should `Extract()`,
+`Expand()`, and/or `Derive()` be used internally, that they can be modeled as functions
+independent from the invocations of these functions in the
+remainder of HPKE. One way to ensure this is by using `LabeledExtract()` /
+`LabeledExpand()` / `LabeledDerive()` functions with a `suite_id` as defined in {{base-crypto}},
 which will ensure input domain separation, as outlined above.
 Particular attention needs to
 be paid if the KEM directly invokes functions that are used internally
@@ -1591,7 +1669,7 @@ inputs to the internal invocations of these functions inside `Extract()` or
 `Expand()`. In HPKE's `KeySchedule()` this is avoided by using `Extract()` instead of
 `Hash()` on the arbitrary-length inputs `info` and `psk_id`.
 
-The string literal "HPKE-v1" used in `LabeledExtract()` and `LabeledExpand()`
+The string literal "HPKE-v1" used in `LabeledExtract()` / `LabeledExpand()` / `LabeledDerive()`
 ensures that any secrets derived in HPKE are bound to the scheme's name
 and version, even when possibly derived from the same Diffie-Hellman or
 KEM shared secret as in another scheme or version.

--- a/draft-barnes-hpke-hpke.md
+++ b/draft-barnes-hpke-hpke.md
@@ -1194,12 +1194,12 @@ algorithm whose output length is `Npk`.
 
 ## Key Derivation Functions (KDFs) {#kdf-ids}
 
-| Value  | KDF         | Nh  | Reference    |
-|:-------|:------------|-----|:-------------|
-| 0x0000 | Reserved    | N/A | RFC 9180     |
-| 0x0001 | HKDF-SHA256 | 32  | {{?RFC5869}} |
-| 0x0002 | HKDF-SHA384 | 48  | {{?RFC5869}} |
-| 0x0003 | HKDF-SHA512 | 64  | {{?RFC5869}} |
+| Value  | KDF         | Nh  | Two-Stage | Reference    |
+|:-------|:------------|-----|-----------|:-------------|
+| 0x0000 | Reserved    | N/A | N/A       | RFC 9180     |
+| 0x0001 | HKDF-SHA256 | 32  | Y         | {{?RFC5869}} |
+| 0x0002 | HKDF-SHA384 | 48  | Y         | {{?RFC5869}} |
+| 0x0003 | HKDF-SHA512 | 64  | Y         | {{?RFC5869}} |
 {: #kdfid-values title="KDF IDs"}
 
 ### Input Length Restrictions {#kdf-input-length}
@@ -1861,9 +1861,16 @@ Template:
 * Value: The two-byte identifier for the algorithm
 * KDF: The name of the algorithm
 * Nh: The output size of the Extract function in bytes
+* Two-Stage: Whether this is a two-stage KDF.  Allowed values are:
+    * "Y" - This is a two-stage KDF
+    * "N" - This is a single-stage KDF
 * Reference: Where this algorithm is defined
 
 Initial contents: Provided in {{kdfid-values}}
+
+This document updates the existing registry by adding the "Two-Stage" column.
+Existing registry values should be updated with a value of "Y" in this column,
+as reflected in {{kdfid-values}}.
 
 ## AEAD Identifiers
 

--- a/draft-barnes-hpke-hpke.md
+++ b/draft-barnes-hpke-hpke.md
@@ -226,7 +226,7 @@ informative:
   keyagreement: DOI.10.6028/NIST.SP.800-56Ar3
 
   NISTCurves: DOI.10.6028/NIST.FIPS.186-4
-  
+
   FIPS202: DOI.10.6028/NIST.FIPS.202
 
   GCM: DOI.10.6028/NIST.SP.800-38D
@@ -358,7 +358,7 @@ HPKE variants rely on the following primitives:
     - `Derive(ikm, L)`: Derive an `L`-byte value from the input keying material
       `ikm`.
     - `Nh` The security strength of the KDF, in bytes.
-  
+
   * A two-stage KDF:
     - `Extract(salt, ikm)`: Extract a pseudorandom key of fixed length `Nh` bytes
       from input keying material `ikm` and an optional byte string
@@ -456,7 +456,7 @@ for the Diffie-Hellman group in use. {{derive-key-pair}} contains the
 # For use with single-stage KDFs
 def ExtractAndExpand(dh, kem_context):
   derive_input = concat(
-    lengthPrefixed(dh), 
+    lengthPrefixed(dh),
     lengthPrefixed(shared_secret)
   )
   return LabeledDerive(derive_input, "shared_secret", Nsecret)
@@ -713,7 +713,7 @@ def KeySchedule<ROLE>(mode, shared_secret, info, psk, psk_id):
 
   key, base_nonce, exporter_secret =
     CombineSecrets(mode, shared_secret, info, psk, psk_id)
-  
+
   return Context<ROLE>(key, base_nonce, 0, exporter_secret)
 ~~~~~
 

--- a/draft-barnes-hpke-hpke.md
+++ b/draft-barnes-hpke-hpke.md
@@ -418,7 +418,7 @@ def LabeledExpand(prk, label, info, L):
   return Expand(prk, labeled_info, L)
 
 def LabeledDerive(ikm, label, L):
-  labeled_ikm = concat("HPKE_v1", suite_id, label, ikm)
+  labeled_ikm = concat("HPKE_v1", suite_id, label, I2OSP(L, 2), ikm)
   return Derive(labeled_ikm, L)
 ~~~
 

--- a/draft-barnes-hpke-hpke.md
+++ b/draft-barnes-hpke-hpke.md
@@ -408,6 +408,14 @@ The following functions are defined to facilitate domain separation of
 KDF calls as well as context binding:
 
 ~~~
+# For use with single-stage KDFs
+def LabeledDerive(ikm, label, L):
+  labeled_ikm = concat("HPKE_v1", suite_id, label, I2OSP(L, 2), ikm)
+  return Derive(labeled_ikm, L)
+~~~
+
+~~~
+# For use with two-stage KDFs
 def LabeledExtract(salt, label, ikm):
   labeled_ikm = concat("HPKE-v1", suite_id, label, ikm)
   return Extract(salt, labeled_ikm)
@@ -416,10 +424,6 @@ def LabeledExpand(prk, label, info, L):
   labeled_info = concat(I2OSP(L, 2), "HPKE-v1", suite_id,
                         label, info)
   return Expand(prk, labeled_info, L)
-
-def LabeledDerive(ikm, label, L):
-  labeled_ikm = concat("HPKE_v1", suite_id, label, I2OSP(L, 2), ikm)
-  return Derive(labeled_ikm, L)
 ~~~
 
 The value of `suite_id` depends on where the KDF is used; it is assumed
@@ -1861,16 +1865,9 @@ Template:
 * Value: The two-byte identifier for the algorithm
 * KDF: The name of the algorithm
 * Nh: The output size of the Extract function in bytes
-* Two-Stage: Whether this is a two-stage KDF.  Allowed values are:
-    * "Y" - This is a two-stage KDF
-    * "N" - This is a single-stage KDF
 * Reference: Where this algorithm is defined
 
 Initial contents: Provided in {{kdfid-values}}
-
-This document updates the existing registry by adding the "Two-Stage" column.
-Existing registry values should be updated with a value of "Y" in this column,
-as reflected in {{kdfid-values}}.
 
 ## AEAD Identifiers
 

--- a/draft-barnes-hpke-hpke.md
+++ b/draft-barnes-hpke-hpke.md
@@ -457,7 +457,7 @@ for the Diffie-Hellman group in use. {{derive-key-pair}} contains the
 def ExtractAndExpand(dh, kem_context):
   derive_input = concat(
     lengthPrefixed(dh),
-    lengthPrefixed(shared_secret)
+    lengthPrefixed(kem_context)
   )
   return LabeledDerive(derive_input, "shared_secret", Nsecret)
 

--- a/draft-barnes-hpke-hpke.md
+++ b/draft-barnes-hpke-hpke.md
@@ -411,9 +411,9 @@ KDF calls as well as context binding:
 # For use with single-stage KDFs
 def LabeledDerive(ikm, label, context, L):
   labeled_ikm = concat(
-    ikm, 
-    "HPKE_v1", 
-    suite_id, 
+    ikm,
+    "HPKE_v1",
+    suite_id,
     lengthPrefixed(label),
     lengthPrefixed(context),
     I2OSP(L, 4)

--- a/draft-ietf-hpke-hpke.md
+++ b/draft-ietf-hpke-hpke.md
@@ -441,10 +441,12 @@ this KEM algorithm; if used in the remainder of HPKE, it MUST start with
 and {{encryption-context}} for details.
 
 Certain functions have a different structure depending on whether a one-stage or
-two-stage KDF is being used.  Implementations of such functions will have the
-suffixes `_OneStage` and `_TwoStage`, respectively.  For example, the `Foo`
-function would be invoked by calling `Foo_OneStage` when using a one-stage KDF,
-and by calling `Foo_TwoStage` when using a two-stage KDF.
+two-stage KDF is being used.  For clarity, such functions will be described
+twice in this document, once with the suffix `_OneStage` and once with the
+suffix `_TwoStage`, representing the versions of the function to be used with a
+one-stage or two-stage KDF, respectively.  For example, the `Foo` function would
+be invoked by calling `Foo_OneStage` when using a one-stage KDF, and by calling
+`Foo_TwoStage` when using a two-stage KDF.
 
 ## DH-Based KEM (DHKEM) {#dhkem}
 


### PR DESCRIPTION
This PR adds support for single-stage KDFs, for example, SHAKE or TurboSHAKE.  As [discussed on the CFRG list](https://mailarchive.ietf.org/arch/msg/cfrg/L8sWP0VdrKLKp_MUbgjSqx5ArMw/), these KDFs can make HPKE up to 20% faster.

I have implemented this change by generally making single-stage and two-stage KDFs parallel.  It would have disturbed less text to treat single-stage KDFs as an add-on / alternative to the base RFC 9180 two-stage KDF definition.  But I think this ends up being a little cleaner.

The part I am least confident about is the security considerations.  I added some text to the Domain Separation section that I think is true.  I had no idea what to put in the Input Length Restrictions section, so I just added a TODO.

Fixes #3 