### PR TITLE
Use the same label for one- and two-stage KDFs

### DIFF
--- a/draft-ietf-hpke-hpke.md
+++ b/draft-ietf-hpke-hpke.md
@@ -397,7 +397,7 @@ KDF calls as well as context binding:
 def LabeledDerive(ikm, label, context, L):
   labeled_ikm = concat(
     ikm,
-    "HPKE_v1",
+    "HPKE-v1",
     suite_id,
     lengthPrefixed(label),
     I2OSP(L, 2)


### PR DESCRIPTION
ht @bwesterb for pointing out that these labels are inconsistent.