### PR TITLE
Clarify Nh and IANA KDF template for one-stage KDFs

### DIFF
--- a/draft-ietf-hpke-hpke.md
+++ b/draft-ietf-hpke-hpke.md
@@ -339,7 +339,7 @@ HPKE variants rely on the following primitives:
   * A one-stage KDF:
     - `Derive(ikm, L)`: Derive an `L`-byte value from the input keying material
       `ikm`.
-    - `Nh` The security strength of the KDF, in bytes.
+    - `Nh`: The security strength of the KDF in bytes.
 
   * A two-stage KDF:
     - `Extract(salt, ikm)`: Extract a pseudorandom key of fixed length `Nh` bytes
@@ -1734,7 +1734,12 @@ Template:
 
 * Value: The two-byte identifier for the algorithm
 * KDF: The name of the algorithm
-* Nh: The output size of the Extract function in bytes
+* Nh: For two-stage KDFs, the output size of the Extract function in
+  bytes.  For one-stage KDFs, the security strength in bytes, as
+  defined for the KDF identifier.
+* Two-Stage: Whether the KDF provides Extract and Expand functions (Y)
+  or only a single-stage Derive function (N).  N/A for reserved
+  entries.
 * Reference: Where this algorithm is defined
 
 Initial contents: Provided in {{kdfid-values}}


### PR DESCRIPTION
Two small fixes:

1. One-stage Nh description: add missing colon to match two-stage
   style.

2. IANA KDF template: expand Nh definition to cover both one-stage
   and two-stage KDFs, add Two-Stage field to match the existing
   table in the document body.