### PR TITLE
Add edge-case test vectors

### DIFF
--- a/draft-ietf-hpke-hpke.md
+++ b/draft-ietf-hpke-hpke.md
@@ -3253,3 +3253,261 @@ L: 32
 exported_value:
 7c9d79876a288507b81a5a52365a7d39cc0fa3f07e34172984f96fec07c44cba
 ~~~
+
+# Edge-Case Test Vectors
+
+This appendix contains test vectors that exercise behavior defined by HPKE itself -- DeriveKeyPair rejection sampling, the labeled key schedule, and the handling of empty and zero-byte inputs -- rather than the underlying KEM, KDF, and AEAD primitives.  Except for the rejection-sampling vector in the first section, all vectors use the suite DHKEM(X25519, HKDF-SHA256), HKDF-SHA256, AES-128-GCM, because the behavior exercised is independent of the choice of KEM, KDF, and AEAD.
+
+## KEM Key Derivation with Rejection Sampling
+
+In this vector the recipient `ikm` is chosen so that the candidate private key derived with `counter = 0` (`rejected_candidate` below) is greater than or equal to the order of the P-256 group and is therefore rejected; the key pair is produced from the candidate at `counter = 1`.  This exercises the rejection sampling loop in `DeriveKeyPair`.
+
+### Base Setup Information
+~~~
+mode: 0
+kem_id: 16
+kdf_id: 1
+aead_id: 1
+info: 4f6465206f6e2061204772656369616e2055726e
+ikmE: 4270e54ffd08d79d5928020af4686d8f6b7d35dbe470265f1f5aa22816ce860e
+ikmR: 68706b652d656467652d703235362d72656a656374696f6e00000001c6be4ce7
+rejected_candidate (counter=0):
+ffffffffc6e92ab863d8293933c849d280fc9a40f07471a06702bdf2eac30fa2
+skRm: d9cbff7adaa1c604a2e4fcfb762c9e1c5ed7d2e33b15fcad4c6c3f23a9637325
+pkRm:
+04d3bec6a691f47bbedd5caa1d51c7228f6afeeec5576495b855bbe6595e49643570be
+005fc177b3d80f6eeef280b1cf8a565d7ca28116dee2e875550ef3050ca8
+enc:
+04a92719c6195d5085104f469a8b9814d5838ff72b60501e2c4466e5e67b325ac98536
+d7b61a1af4b78e5b7f951c0900be863c403ce65c9bfcb9382657222d18c4
+shared_secret:
+1f38c13d9156ad1439d1edf648a12bf9c62cecb95cbb2087e16683636744251a
+key: 58337e18488e9e09ab4278759207d006
+base_nonce: d4967824655d4887a04b3d87
+exporter_secret:
+04f68c9f58b994666057b92606f7b738c47300fcb3a33bac157ee4a934bbae25
+~~~
+
+#### Encryptions
+~~~
+sequence number: 0
+pt: 4265617574792069732074727574682c20747275746820626561757479
+aad: 436f756e742d30
+nonce: d4967824655d4887a04b3d87
+ct:
+bcf25d5db84780b5b222eb26a63d8fb489c6a0bf1f6281cbc10c633707dbcda9af7cee
+7a57abdb59ce4c9d4162
+~~~
+
+#### Exported Values
+~~~
+exporter_context: 54657374436f6e74657874
+L: 32
+exported_value:
+abd921fc81dae75036e9146d2e5826e3ea075b410c1c46a0a0533a9e3e685490
+~~~
+
+## Empty and Zero-Byte AEAD Inputs
+
+This vector uses a normal context and exercises empty and zero-byte values for the per-message `aad` and `pt` inputs and the `exporter_context` input.
+
+### Base Setup Information
+~~~
+mode: 0
+kem_id: 32
+kdf_id: 1
+aead_id: 1
+info: 4f6465206f6e2061204772656369616e2055726e
+ikmE: 7268600d403fce431561aef583ee1613527cff655c1343f29812e66706df3234
+ikmR: 6db9df30aa07dd42ee5e8181afdb977e538f5e1fec8a06223f33f7013e525037
+skRm: 4612c550263fc8ad58375df3f557aac531d26850903e55a9f23f21d8534e8ac8
+pkRm: 3948cfe0ad1ddb695d780e59077195da6c56506b027329794ab02bca80815c4d
+enc: 37fda3567bdbd628e88668c3c8d7e97d1d1253b6d4ea6d44c150f741f1bf4431
+shared_secret:
+fe0e18c9f024ce43799ae393c7e8fe8fce9d218875e8227b0187c04e7d2ea1fc
+key: 4531685d41d65f03dc48f6b8302c05b0
+base_nonce: 56d890e5accaaf011cff4b7d
+exporter_secret:
+45ff1c2e220db587171952c0592d5f5ebe103f1561a2614e38f2ffd47e99e3f8
+~~~
+
+#### Encryptions
+~~~
+sequence number: 0
+pt:
+aad: 436f756e742d30
+nonce: 56d890e5accaaf011cff4b7d
+ct: 3f431133aa05608a56675bec51d03e0f
+
+sequence number: 1
+pt: 4265617574792069732074727574682c20747275746820626561757479
+aad:
+nonce: 56d890e5accaaf011cff4b7c
+ct:
+af2d7e9ac9ae7e270f46ba1f975be53c09f8d875bdc8535458c2494e8aa7d2bb71109b
+5730bb714a8e64e5cc16
+
+sequence number: 2
+pt: 00010002000300
+aad: 436f756e742d30
+nonce: 56d890e5accaaf011cff4b7f
+ct: 0be99ddcad54aabf548b3dbae884aff7aaeb0afc9ab60f
+
+sequence number: 3
+pt: 4265617574792069732074727574682c20747275746820626561757479
+aad: 00ff00ff00
+nonce: 56d890e5accaaf011cff4b7e
+ct:
+6b0f4cd351730cd25993d8ad0f11bff1ef2c3a957cb4d8694bb06c60a2f65e4f4cf8c1
+ae35431071bb18eff3e8
+~~~
+
+#### Exported Values
+~~~
+exporter_context:
+L: 32
+exported_value:
+3853fe2b4035195a573ffc53856e77058e15d9ea064de3e59f4961d0095250ee
+
+exporter_context: 00
+L: 32
+exported_value:
+2e8f0b54673c7029649d4eb9d5e33bf1872cf76d623ff164ac185da9e88c21a5
+
+exporter_context: 0011002200
+L: 32
+exported_value:
+73ac25f70dd55c215b4220e6978533ee2d3a559a48c507b11e200af81e64337a
+~~~
+
+## Empty info
+
+This vector uses an empty `info` value in the key schedule.
+
+### Base Setup Information
+~~~
+mode: 0
+kem_id: 32
+kdf_id: 1
+aead_id: 1
+info:
+ikmE: 7268600d403fce431561aef583ee1613527cff655c1343f29812e66706df3234
+ikmR: 6db9df30aa07dd42ee5e8181afdb977e538f5e1fec8a06223f33f7013e525037
+skRm: 4612c550263fc8ad58375df3f557aac531d26850903e55a9f23f21d8534e8ac8
+pkRm: 3948cfe0ad1ddb695d780e59077195da6c56506b027329794ab02bca80815c4d
+enc: 37fda3567bdbd628e88668c3c8d7e97d1d1253b6d4ea6d44c150f741f1bf4431
+shared_secret:
+fe0e18c9f024ce43799ae393c7e8fe8fce9d218875e8227b0187c04e7d2ea1fc
+key: a9b96236b306695e8729863403f68d4f
+base_nonce: 0816b7f1635cce3ee2a7f611
+exporter_secret:
+ac9efc2aea9784504d6e817cf056845b1947cb604e6f398704c0524a1cc8e90f
+~~~
+
+#### Encryptions
+~~~
+sequence number: 0
+pt: 4265617574792069732074727574682c20747275746820626561757479
+aad: 436f756e742d30
+nonce: 0816b7f1635cce3ee2a7f611
+ct:
+2a19b5c53b9bc4d52723cfa64b0c0532b9fd5473e8c1105285be1a5fd763463c3d3423
+6f5d26ebfe906277e094
+~~~
+
+#### Exported Values
+~~~
+exporter_context: 54657374436f6e74657874
+L: 32
+exported_value:
+8a02de446479bb7d27490ed85a69c6bbaddd0969fbc84f7661ab038c9008f053
+~~~
+
+## info with Embedded Zero Bytes
+
+This vector uses an `info` value that contains embedded zero bytes in the key schedule.
+
+### Base Setup Information
+~~~
+mode: 0
+kem_id: 32
+kdf_id: 1
+aead_id: 1
+info: f0000f00ff
+ikmE: 7268600d403fce431561aef583ee1613527cff655c1343f29812e66706df3234
+ikmR: 6db9df30aa07dd42ee5e8181afdb977e538f5e1fec8a06223f33f7013e525037
+skRm: 4612c550263fc8ad58375df3f557aac531d26850903e55a9f23f21d8534e8ac8
+pkRm: 3948cfe0ad1ddb695d780e59077195da6c56506b027329794ab02bca80815c4d
+enc: 37fda3567bdbd628e88668c3c8d7e97d1d1253b6d4ea6d44c150f741f1bf4431
+shared_secret:
+fe0e18c9f024ce43799ae393c7e8fe8fce9d218875e8227b0187c04e7d2ea1fc
+key: 7d8ac6f5d6276d9411b66d4bfa232381
+base_nonce: 626c42fcd01b1690bf10cb44
+exporter_secret:
+47c5306e700000a21465f2efd0c81d8df46e607b538fb330b213726d1004899e
+~~~
+
+#### Encryptions
+~~~
+sequence number: 0
+pt: 4265617574792069732074727574682c20747275746820626561757479
+aad: 436f756e742d30
+nonce: 626c42fcd01b1690bf10cb44
+ct:
+dccc58fdd5dd0f80a162809a6bd47bf881ce2821b5ab718892dd568e2dcef6c98750fa
+1dc39a6182802ef3416c
+~~~
+
+#### Exported Values
+~~~
+exporter_context: 54657374436f6e74657874
+L: 32
+exported_value:
+b16979c789e60ff4a21a3975b785ed3114d44525a3f660a4a848891dcf54446a
+~~~
+
+## psk and psk_id with Embedded Zero Bytes
+
+This vector uses PSK mode with a `psk` and `psk_id` that contain embedded zero bytes.
+
+### PSK Setup Information
+~~~
+mode: 1
+kem_id: 32
+kdf_id: 1
+aead_id: 1
+info: 4f6465206f6e2061204772656369616e2055726e
+ikmE: 78628c354e46f3e169bd231be7b2ff1c77aa302460a26dbfa15515684c00130b
+ikmR: d4a09d09f575fef425905d2ab396c1449141463f698f8efdb7accfaff8995098
+skRm: c5eb01eb457fe6c6f57577c5413b931550a162c71a03ac8d196babbd4e5ce0fd
+pkRm: 9fed7e8c17387560e92cc6462a68049657246a09bfa8ade7aefe589672016366
+enc: 0ad0950d9fb9588e59690b74f1237ecdf1d775cd60be2eca57af5a4b0471c91b
+shared_secret:
+727699f009ffe3c076315019c69648366b69171439bd7dd0807743bde76986cd
+key: ca4f3f1e77364e55e5554d480a8ee58a
+base_nonce: a8cf850e9bdd7d73155a5243
+exporter_secret:
+d08a0e5476626a7fccf354ec6b1787a238e53f8e38e96af3d2c4f76f6295007b
+psk: 0000000000000000111111111111111100000000000000002222222222222222
+psk_id: 0050534b00696400
+~~~
+
+#### Encryptions
+~~~
+sequence number: 0
+pt: 4265617574792069732074727574682c20747275746820626561757479
+aad: 436f756e742d30
+nonce: a8cf850e9bdd7d73155a5243
+ct:
+cf34c6d0f86cd81c527cff7a2a20541cd017877d6e95f82f9dc13e6937bef65723bf43
+d4a2362690c20591ce67
+~~~
+
+#### Exported Values
+~~~
+exporter_context: 54657374436f6e74657874
+L: 32
+exported_value:
+000521bf952f7f7c56cf7dbf40ec1f6943a3233abe36a72d20aa4f87e0d90a95
+~~~
+

--- a/test-vectors/Cargo.toml
+++ b/test-vectors/Cargo.toml
@@ -17,3 +17,11 @@ path = "src/bin/generate.rs"
 [[bin]]
 name = "json-to-markdown"
 path = "src/bin/json-to-markdown.rs"
+
+[[bin]]
+name = "edge-vectors"
+path = "src/bin/edge-vectors.rs"
+
+[[bin]]
+name = "search-p256"
+path = "src/bin/search-p256.rs"

--- a/test-vectors/src/bin/edge-vectors.rs
+++ b/test-vectors/src/bin/edge-vectors.rs
@@ -1,0 +1,300 @@
+// Generate the "Edge-Case Test Vectors" appendix for draft-ietf-hpke-hpke.
+//
+// These vectors exercise behavior defined by HPKE itself (its labeled key
+// schedule, DeriveKeyPair rejection sampling, and forwarding of empty/zero-byte
+// inputs), as opposed to the underlying AEAD/KDF/curve primitives, which have
+// their own test vectors.
+//
+// All vectors except the KEM rejection-sampling case (C.1) use the single suite
+// DHKEM(X25519, HKDF-SHA256) / HKDF-SHA256 / AES-128-GCM, because the behavior
+// exercised is independent of the choice of KEM, KDF, and AEAD.
+//
+// Run with: cargo run --bin edge-vectors
+
+use hpke_ref::*;
+
+// ----- canonical key material reused from the main (RFC 9180) vectors -----
+// Base context (X25519/HKDF-SHA256/AES-128-GCM):
+const X_IKM_E: &str = "7268600d403fce431561aef583ee1613527cff655c1343f29812e66706df3234";
+const X_IKM_R: &str = "6db9df30aa07dd42ee5e8181afdb977e538f5e1fec8a06223f33f7013e525037";
+const INFO: &str = "4f6465206f6e2061204772656369616e2055726e"; // "Ode on a Grecian Urn"
+// PSK context:
+const X_PSK_IKM_E: &str = "78628c354e46f3e169bd231be7b2ff1c77aa302460a26dbfa15515684c00130b";
+const X_PSK_IKM_R: &str = "d4a09d09f575fef425905d2ab396c1449141463f698f8efdb7accfaff8995098";
+
+// P-256 ephemeral ikm (reused from the main P-256 vectors); the recipient ikm
+// below is the special one that triggers rejection sampling.
+const P_IKM_E: &str = "4270e54ffd08d79d5928020af4686d8f6b7d35dbe470265f1f5aa22816ce860e";
+// suite_id for DHKEM(P-256, HKDF-SHA256), used to recompute the rejected candidate.
+const KEM_P256_SUITE_ID: &[u8] = &[0x4b, 0x45, 0x4d, 0x00, 0x10];
+
+// Found by search-p256: DeriveKeyPair rejects the counter=0 candidate (its first
+// four bytes are 0xffffffff, making it >= the P-256 group order) and uses counter=1.
+const P256_REJECT_IKM: &str = "68706b652d656467652d703235362d72656a656374696f6e00000001c6be4ce7";
+
+// Canonical plaintext/aad/exporter_context, plus zero-byte edge values.
+const PT: &str = "4265617574792069732074727574682c20747275746820626561757479";
+const AAD: &str = "436f756e742d30"; // "Count-0"
+const EXP_CTX: &str = "54657374436f6e74657874"; // "TestContext"
+
+fn h(s: &str) -> Vec<u8> {
+    hex::decode(s).unwrap()
+}
+
+// --- hex formatting, matching the existing test-vector appendix ---
+const MAX_LINE_LENGTH: usize = 70;
+
+fn format_hex(data: &[u8], label: &str) -> String {
+    let hex_string = hex::encode(data);
+    if label.len() + hex_string.len() <= MAX_LINE_LENGTH {
+        return hex_string;
+    }
+    let mut result = String::from("\n");
+    for chunk in hex_string
+        .chars()
+        .collect::<Vec<_>>()
+        .chunks(MAX_LINE_LENGTH)
+    {
+        result.push_str(&chunk.iter().collect::<String>());
+        result.push('\n');
+    }
+    result.pop();
+    result
+}
+
+fn field(label: &str, data: &[u8]) -> String {
+    // Strip any trailing whitespace left when the value is empty or wraps to a
+    // new line (e.g. "shared_secret: \n..."), so the output is lint-clean.
+    let line = format!("{}{}", label, format_hex(data, label));
+    let cleaned = line
+        .split('\n')
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!("{}\n", cleaned)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_context<K, H, A>(
+    title: &str,
+    intro: &str,
+    mode: Mode,
+    info: &[u8],
+    psk: &[u8],
+    psk_id: &[u8],
+    ikm_r: &[u8],
+    ikm_e: &[u8],
+    extra_setup: &[String],
+    encryptions: &[(&[u8], &[u8])], // (pt, aad) in sequence
+    exports: &[(&[u8], u32)],       // (exporter_context, L)
+) -> String
+where
+    K: Kem,
+    H: Kdf,
+    A: Aead,
+{
+    let (sk_r, pk_r) = K::derive_key_pair(ikm_r);
+    let (shared_secret, enc) = K::encap_derand(&pk_r, ikm_e);
+    let suite_id = Instance::<K, H, A>::suite_id();
+    let (key, base_nonce, exporter_secret) = H::combine_secrets(
+        &suite_id,
+        mode,
+        &shared_secret,
+        info,
+        psk,
+        psk_id,
+        A::N_K,
+        A::N_N,
+    );
+
+    let is_psk = matches!(mode, Mode::Psk);
+    let mut o = String::new();
+    o.push_str(&format!("## {}\n\n", title));
+    if !intro.is_empty() {
+        o.push_str(intro);
+        o.push_str("\n\n");
+    }
+
+    let setup = if is_psk {
+        "PSK Setup Information"
+    } else {
+        "Base Setup Information"
+    };
+    o.push_str(&format!("### {}\n~~~\n", setup));
+    o.push_str(&format!("mode: {}\n", u8::from(mode)));
+    o.push_str(&format!("kem_id: {}\n", u16::from_be_bytes(K::ID)));
+    o.push_str(&format!("kdf_id: {}\n", u16::from_be_bytes(H::ID)));
+    o.push_str(&format!("aead_id: {}\n", u16::from_be_bytes(A::ID)));
+    o.push_str(&field("info: ", info));
+    o.push_str(&field("ikmE: ", ikm_e));
+    o.push_str(&field("ikmR: ", ikm_r));
+    for line in extra_setup {
+        o.push_str(line);
+    }
+    o.push_str(&field("skRm: ", &K::serialize_private_key(&sk_r)));
+    o.push_str(&field("pkRm: ", &K::serialize_public_key(&pk_r)));
+    o.push_str(&field("enc: ", &enc));
+    o.push_str(&field("shared_secret: ", &shared_secret));
+    o.push_str(&field("key: ", &key));
+    o.push_str(&field("base_nonce: ", &base_nonce));
+    o.push_str(&field("exporter_secret: ", &exporter_secret));
+    if is_psk {
+        o.push_str(&field("psk: ", psk));
+        o.push_str(&field("psk_id: ", psk_id));
+    }
+    o.push_str("~~~\n\n");
+
+    if A::ID != [0xff, 0xff] && !encryptions.is_empty() {
+        o.push_str("#### Encryptions\n~~~\n");
+        let mut ctx =
+            Context::<A, Sender>::new(key.clone(), base_nonce.clone(), exporter_secret.clone());
+        for (i, (pt, aad)) in encryptions.iter().enumerate() {
+            if i > 0 {
+                o.push('\n');
+            }
+            let nonce = ctx.compute_nonce();
+            let ct = ctx.seal(aad, pt);
+            o.push_str(&format!("sequence number: {}\n", i));
+            o.push_str(&field("pt: ", pt));
+            o.push_str(&field("aad: ", aad));
+            o.push_str(&field("nonce: ", &nonce));
+            o.push_str(&field("ct: ", &ct));
+        }
+        o.push_str("~~~\n\n");
+    }
+
+    if !exports.is_empty() {
+        o.push_str("#### Exported Values\n~~~\n");
+        for (i, (ec, l)) in exports.iter().enumerate() {
+            if i > 0 {
+                o.push('\n');
+            }
+            let ev = H::export(&suite_id, &exporter_secret, ec, *l as usize);
+            let ec_line = format!("exporter_context: {}", hex::encode(ec));
+            o.push_str(ec_line.trim_end());
+            o.push('\n');
+            o.push_str(&format!("L: {}\n", l));
+            o.push_str(&field("exported_value: ", &ev));
+        }
+        o.push_str("~~~\n\n");
+    }
+
+    o
+}
+
+fn main() {
+    let mut out = String::new();
+    out.push_str("# Edge-Case Test Vectors\n\n");
+    out.push_str(
+        "This appendix contains test vectors that exercise behavior defined by HPKE \
+itself -- DeriveKeyPair rejection sampling, the labeled key schedule, and the \
+handling of empty and zero-byte inputs -- rather than the underlying KEM, KDF, \
+and AEAD primitives.  Except for the rejection-sampling vector in the first \
+section, all vectors use the suite DHKEM(X25519, HKDF-SHA256), HKDF-SHA256, \
+AES-128-GCM, because the behavior exercised is independent of the choice of \
+KEM, KDF, and AEAD.\n\n",
+    );
+
+    // ---- C.1: P-256 DeriveKeyPair rejection sampling ----
+    let reject_ikm = h(P256_REJECT_IKM);
+    let cand0 = HkdfSha256::derive_candidate(KEM_P256_SUITE_ID, &reject_ikm, 0, 32);
+    let extra = vec![field("rejected_candidate (counter=0): ", &cand0)];
+    out.push_str(&render_context::<DhkemP256HkdfSha256, HkdfSha256, Aes128Gcm>(
+        "KEM Key Derivation with Rejection Sampling",
+        "In this vector the recipient `ikm` is chosen so that the candidate private \
+key derived with `counter = 0` (`rejected_candidate` below) is greater than or \
+equal to the order of the P-256 group and is therefore rejected; the key pair is \
+produced from the candidate at `counter = 1`.  This exercises the rejection \
+sampling loop in `DeriveKeyPair`.",
+        Mode::Base,
+        &h(INFO),
+        &[],
+        &[],
+        &reject_ikm,
+        &h(P_IKM_E),
+        &extra,
+        &[(&h(PT), &h(AAD))],
+        &[(&h(EXP_CTX), 32)],
+    ));
+
+    // ---- C.2: empty and zero-byte AEAD inputs + exporter_context ----
+    let zb_aad = vec![0x00u8, 0xff, 0x00, 0xff, 0x00];
+    let zb_pt = vec![0x00u8, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00];
+    let zb_ctx = vec![0x00u8, 0x11, 0x00, 0x22, 0x00];
+    out.push_str(&render_context::<DhkemX25519HkdfSha256, HkdfSha256, Aes128Gcm>(
+        "Empty and Zero-Byte AEAD Inputs",
+        "This vector uses a normal context and exercises empty and zero-byte values \
+for the per-message `aad` and `pt` inputs and the `exporter_context` input.",
+        Mode::Base,
+        &h(INFO),
+        &[],
+        &[],
+        &h(X_IKM_R),
+        &h(X_IKM_E),
+        &[],
+        &[
+            (&[], &h(AAD)),       // empty pt
+            (&h(PT), &[]),        // empty aad
+            (&zb_pt, &h(AAD)),    // pt with embedded zero bytes
+            (&h(PT), &zb_aad),    // aad with embedded zero bytes
+        ],
+        &[
+            (&[], 32),       // empty exporter_context
+            (&[0x00], 32),   // single zero byte
+            (&zb_ctx, 32),   // embedded zero bytes
+        ],
+    ));
+
+    // ---- C.3: empty info ----
+    out.push_str(&render_context::<DhkemX25519HkdfSha256, HkdfSha256, Aes128Gcm>(
+        "Empty info",
+        "This vector uses an empty `info` value in the key schedule.",
+        Mode::Base,
+        &[],
+        &[],
+        &[],
+        &h(X_IKM_R),
+        &h(X_IKM_E),
+        &[],
+        &[(&h(PT), &h(AAD))],
+        &[(&h(EXP_CTX), 32)],
+    ));
+
+    // ---- C.4: zero-byte info ----
+    let zb_info = vec![0xf0u8, 0x00, 0x0f, 0x00, 0xff];
+    out.push_str(&render_context::<DhkemX25519HkdfSha256, HkdfSha256, Aes128Gcm>(
+        "info with Embedded Zero Bytes",
+        "This vector uses an `info` value that contains embedded zero bytes in the \
+key schedule.",
+        Mode::Base,
+        &zb_info,
+        &[],
+        &[],
+        &h(X_IKM_R),
+        &h(X_IKM_E),
+        &[],
+        &[(&h(PT), &h(AAD))],
+        &[(&h(EXP_CTX), 32)],
+    ));
+
+    // ---- C.5: zero-byte psk and psk_id ----
+    // psk retains 32 bytes of length, with embedded zero bytes.
+    let zb_psk = h("0000000000000000111111111111111100000000000000002222222222222222");
+    let zb_psk_id = vec![0x00u8, 0x50, 0x53, 0x4b, 0x00, 0x69, 0x64, 0x00]; // "\0PSK\0id\0"
+    out.push_str(&render_context::<DhkemX25519HkdfSha256, HkdfSha256, Aes128Gcm>(
+        "psk and psk_id with Embedded Zero Bytes",
+        "This vector uses PSK mode with a `psk` and `psk_id` that contain embedded \
+zero bytes.",
+        Mode::Psk,
+        &h(INFO),
+        &zb_psk,
+        &zb_psk_id,
+        &h(X_PSK_IKM_R),
+        &h(X_PSK_IKM_E),
+        &[],
+        &[(&h(PT), &h(AAD))],
+        &[(&h(EXP_CTX), 32)],
+    ));
+
+    print!("{}", out);
+}

--- a/test-vectors/src/bin/search-p256.rs
+++ b/test-vectors/src/bin/search-p256.rs
@@ -1,0 +1,79 @@
+// One-off search: find an `ikm` for DHKEM(P-256, HKDF-SHA256) whose
+// DeriveKeyPair rejects the counter=0 candidate (candidate >= group order),
+// so the key pair is produced at counter=1.  This exercises the rejection
+// sampling loop, which every other published vector skips.
+//
+// Run with: cargo run --release --bin search-p256
+//
+// The result `ikm` is then hard-coded into the edge-vectors generator.
+
+use hpke_ref::*;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+
+// suite_id for DHKEM(P-256, HKDF-SHA256): "KEM" || I2OSP(0x0010, 2)
+const KEM_SUITE_ID: &[u8] = &[0x4b, 0x45, 0x4d, 0x00, 0x10];
+
+// 24-byte ASCII prefix; the trailing 8 bytes are a big-endian counter -> 32-byte ikm.
+fn ikm_for(n: u64) -> Vec<u8> {
+    let mut v = b"hpke-edge-p256-rejection".to_vec();
+    v.extend_from_slice(&n.to_be_bytes());
+    v
+}
+
+fn main() {
+    let order = hex::decode(
+        "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+    )
+    .unwrap();
+
+    let nthreads = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4);
+    eprintln!("searching with {} threads...", nthreads);
+
+    let found = Arc::new(AtomicBool::new(false));
+    let result = Arc::new(AtomicU64::new(0));
+    let counter = Arc::new(AtomicU64::new(0));
+
+    let mut handles = Vec::new();
+    for tid in 0..nthreads {
+        let found = found.clone();
+        let result = result.clone();
+        let counter = counter.clone();
+        let order = order.clone();
+        handles.push(std::thread::spawn(move || {
+            let mut n = tid as u64;
+            let step = nthreads as u64;
+            let mut local: u64 = 0;
+            while !found.load(Ordering::Relaxed) {
+                let ikm = ikm_for(n);
+                // For P-256 the bitmask is 0xff, so the candidate is used unmasked.
+                let cand = HkdfSha256::derive_candidate(KEM_SUITE_ID, &ikm, 0, 32);
+                if cand.as_slice() >= order.as_slice() {
+                    if !found.swap(true, Ordering::Relaxed) {
+                        result.store(n, Ordering::Relaxed);
+                        println!(
+                            "FOUND n={} ikm={} candidate0={}",
+                            n,
+                            hex::encode(&ikm),
+                            hex::encode(&cand)
+                        );
+                    }
+                    return;
+                }
+                n += step;
+                local += 1;
+                if local % (1 << 24) == 0 {
+                    let total = counter.fetch_add(1 << 24, Ordering::Relaxed) + (1 << 24);
+                    eprintln!("progress: ~{} candidates tried", total);
+                }
+            }
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+    let n = result.load(Ordering::Relaxed);
+    println!("done; n={} ikm={}", n, hex::encode(ikm_for(n)));
+}


### PR DESCRIPTION
Fixes #65.

Adds an "Edge-Case Test Vectors" appendix (Appendix D) covering cases that
exercise HPKE's own behavior -- not the underlying KEM/KDF/AEAD primitives,
which have their own vectors:

- D.1: DeriveKeyPair rejection sampling for DHKEM(P-256, HKDF-SHA256) -- a
  recipient ikm whose counter=0 candidate exceeds the group order, so the key
  pair is produced at counter=1.
- D.2: empty and zero-byte aad, pt, and exporter_context (incl. the empty
  plaintext case from the issue).
- D.3 / D.4: empty info and info with embedded zero bytes.
- D.5: psk and psk_id with embedded zero bytes.

The non-KEM cases all use DHKEM(X25519, HKDF-SHA256)/HKDF-SHA256/AES-128-GCM,
since the behavior is independent of the suite.
